### PR TITLE
Netcore 2.2 Upgrade

### DIFF
--- a/src/SnakeCase.JsonNet.Tests/SnakeCase.JsonNet.Tests.csproj
+++ b/src/SnakeCase.JsonNet.Tests/SnakeCase.JsonNet.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <AssemblyTitle>SnakeCase.JsonNet.Tests</AssemblyTitle>
     <Company>mrstebo</Company>
     <Product>SnakeCase.JsonNet.Tests</Product>

--- a/src/SnakeCase.JsonNet/SnakeCase.JsonNet.csproj
+++ b/src/SnakeCase.JsonNet/SnakeCase.JsonNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;netcoreapp2.2</TargetFrameworks>
     <AssemblyTitle>SnakeCase.JsonNet</AssemblyTitle>
     <Company>mrstebo</Company>
     <Product>SnakeCase.JsonNet</Product>


### PR DESCRIPTION
Hey,
Just adding dotnet core 2.2 as a build target. Not sure if anything else needs doing to make this work, but it builds and the tests go green.
It seems to work even if you use it from netcore2.2 in its current state anyway, I just wanted to get rid of the build warnings. 😅 